### PR TITLE
Update node-steam and node-dota2 versions and the reference names to the APIs

### DIFF
--- a/core/dota2.js
+++ b/core/dota2.js
@@ -1,6 +1,8 @@
+var logger = require('./logger.js');
 var Dota2 = require('dota2');
 var dota2;
 var inGame = false;
+
 
 exports.init = function(bot) {
   dota2 = new Dota2.Dota2Client(bot, true);
@@ -10,6 +12,22 @@ exports.launch = function() {
   if (!inGame) {
     dota2.launch();
     inGame = true;
+
+    dota2.on('ready', function() {
+      logger.log('Dota2 is ready to do things.');
+    });
+
+    dota2.on('partyInviteUpdate', function(party) {
+	    console.log(party);
+      var partyId = party.group_id;
+      dota2.respondPartyInvite(partyId, true);
+      dota2.joinChat(partyId);
+    });
+
+    dota2.on('chatMessage', function(channel, senderName, message, chatObject) {
+      logger.log('[messaged receieved] ' + senderName +  ': ' + message + '. On ' + channel);
+	  logger.log(chatObject);
+    });
   }
 };
 

--- a/core/friends.js
+++ b/core/friends.js
@@ -154,13 +154,27 @@ exports.removeFriend = function(id, cb) {
 };
 
 // Grabs what names it can from bot.users and applies them to the friends list.
-exports.updateFriendsNames = function() {
-  for (var friend in friends) {
-    if (bot.users.hasOwnProperty(friend) && friends.hasOwnProperty(friend)) {
-      friends[friend].name = bot.users[friend].playerName;
-    }
+/*
+* bot.users was old, new thing is bot.friends
+* bot.friends is an object of the user's steamId and the friend type, ie: '765...': 3,
+*/
+exports.updateFriendsNames = function(steamId, username) {
+  console.log(bot.friends);
+  // console.log(bot.requestFriendData(bot.friends));
+  if (steamId !== null) {
+    exports.set(steamId,'name', username);
   }
-  exports.save();
+  else {
+    exports.addFriend(steamId);
+  }
+  
+  // for (var friend in friends) {
+  //   if (bot.friends.hasOwnProperty(friend) && friends.hasOwnProperty(friend)) {
+      
+	  
+  //   }
+  // }
+  // exports.save();
 };
 
 // Return all friends.

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "dota2": "0.6.0",
+    "dota2": "1.0.1",
     "lodash": "2.4.1",
     "minimap": "0.1.1",
     "request": "2.16.6",
     "semver": "^5.0.1",
-    "steam": "0.6.7"
+    "steam": "1.4.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
Please feel free to reject / give feedback / question on any of the stuff in here.

Steps I took to update:
1. Change package.json to the stable #'s from node-steam and node-dota2
2. Run npm install (had to manually go into both module folders and run the command... did not automatically go through recursively)
3. Tweaked code when a bug was found